### PR TITLE
Exports already defined.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var exports = module.exports = function (doc) {
+exports = module.exports = function (doc) {
   if (!doc) doc = {};
   if (typeof doc === 'string') doc = { cookie: doc };
   if (doc.cookie === undefined) doc.cookie = '';


### PR DESCRIPTION
In CommonJS modules the `exports` variable is already defined, so there is no need for `var` in front of it.
