### PR TITLE
switch option property checks to use hasOwnProperty

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,19 +19,19 @@ exports = module.exports = function (doc) {
     if (!opts) opts = {};
     var newCookie = encodeURIComponent(key) + '=' + encodeURIComponent(value);
 
-    if (opts.expires){
+    if (opts.hasOwnProperty(expires)){
       newCookie += '; expires=' + opts.expires;
     }
 
-    if (opts.path) {
+    if (opts.hasOwnProperty(path)) {
       newCookie += '; path=' + opts.path;
     }
 
-    if (opts.domain) {
+    if (opts.hasOwnProperty(domain)) {
       newCookie += '; domain=' + opts.domain;
     }
 
-    if (opts.secure) {
+    if (opts.hasOwnProperty(secure)) {
       newCookie += '; secure';
     }
 

--- a/index.js
+++ b/index.js
@@ -19,19 +19,19 @@ exports = module.exports = function (doc) {
     if (!opts) opts = {};
     var newCookie = encodeURIComponent(key) + '=' + encodeURIComponent(value);
 
-    if (opts.hasOwnProperty(expires)){
+    if (opts.hasOwnProperty('expires')){
       newCookie += '; expires=' + opts.expires;
     }
 
-    if (opts.hasOwnProperty(path)) {
+    if (opts.hasOwnProperty('path')) {
       newCookie += '; path=' + opts.path;
     }
 
-    if (opts.hasOwnProperty(domain)) {
+    if (opts.hasOwnProperty('domain')) {
       newCookie += '; domain=' + opts.domain;
     }
 
-    if (opts.hasOwnProperty(secure)) {
+    if (opts.hasOwnProperty('secure')) {
       newCookie += '; secure';
     }
 


### PR DESCRIPTION
trying to wipe a property like "path" with an empty string requires
presence checking, not value checking