### PR TITLE
Mocha is a required devDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "karma-cli": "0.0.4",
     "karma-mocha": "^0.1.9",
     "karma-phantomjs-launcher": "^0.1.4",
-    "karma-spec-reporter": "0.0.13"
+    "karma-spec-reporter": "0.0.13",
+    "mocha": "^2.4.5"
   }
 }


### PR DESCRIPTION
As a peerDep of karma-mocha, npm2 used to install mocha automatically.
But that is no longer the case with npm3. peerDeps must be installed
manually. In this case, we need to specify mocha explicitly as a devDep.